### PR TITLE
Updated dockerfile to fix openjdk:17 deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ RUN ./gradlew build
 FROM ubuntu:20.04 as vim-installer
 RUN apt-get update && apt-get install -y vim
 
-FROM openjdk:17
+FROM ubuntu:20.04
+
+RUN apt update
+RUN apt install -y openjdk-17-jdk
 
 COPY --from=BUILD /gradle/build/libs/rest-0.0.1-SNAPSHOT.jar app.jar
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   server:
     build:
@@ -21,6 +19,8 @@ services:
         condition: service_healthy
     networks:
       - laminar-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   mysql:
     image: mysql:latest


### PR DESCRIPTION
This commit updates the build procedure to the dispel4py-server component, to fix the deprecation of  openjdk docker images. 
It also fixes an issue on the docker compose file, that occurs when running with docker under linux.